### PR TITLE
New name for repository

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "nx_parallel"
+name = "nx-parallel"
 authors = [
     {name = "Mridul Seth", email = "mail@mriduls.com"},
 ]


### PR DESCRIPTION
Update `pyproject.toml` to reflect the new name `nx-parallel` for this repo (old name: `nx_parallel`)
Within python we still refer to it as `nx_parallel`.