### PR TITLE
benchmarking infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# asv 
+results/
+html/

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,7 @@
+## Preview benchmarks locally
+
+1. clone this repo
+2. `cd benchmarks`
+3. `asv run` will run the benchmarks on last commit (or `asv continuous base_commit_hash test_commit_hash` to run the benchmark to compare two commits)
+4. `asv publish` will create a `html` folder with the results
+5. `asv preview` will host the results locally at http://127.0.0.1:8080/

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -1,0 +1,40 @@
+{
+    "version": 1,
+
+    "project": "nx-parallel",
+
+    "project_url": "https://github.com/networkx/nx-parallel",
+
+    "repo": "..",
+    
+    "branches": ["main"],
+
+    "build_command": [
+        "python -m pip install build hatchling",
+        "python -m build .",
+        "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+    ],
+
+    "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
+    
+    "dvcs": "git",
+    
+    "environment_type": "virtualenv",
+
+    "show_commit_url": "https://github.com/networkx/nx-parallel/commit/",
+    
+    "matrix": {
+        "networkx":[],
+         "nx-parallel": []
+    },
+    
+    "benchmark_dir": "benchmarks",
+
+    "env_dir": "env",
+
+    "results_dir": "results",
+
+    "html_dir": "html",
+    
+    "build_cache_size": 8
+}

--- a/benchmarks/benchmarks/bench_centrality.py
+++ b/benchmarks/benchmarks/bench_centrality.py
@@ -1,0 +1,22 @@
+import networkx as nx
+import nx_parallel as nxp
+
+
+class BetweennessCentralityBenchmark:
+    params = [("parallel", "normal")]
+    param_names = ["algo_type"]
+
+    def setup(self, algo_type):
+        self.algo_type = algo_type
+
+    def time_betweenness_centrality(self, algo_type):
+        num_nodes, edge_prob = 300, 0.5
+        G = nx.fast_gnp_random_graph(num_nodes, edge_prob, directed=False)
+        if algo_type == "parallel":
+            H = nxp.ParallelGraph(G)            
+            _ = nx.betweenness_centrality(H)
+        elif algo_type == "normal":
+            _ = nx.betweenness_centrality(G)
+        else:
+            raise ValueError("Unknown algo_type") 
+        


### PR DESCRIPTION
issue https://github.com/networkx/nx-parallel/issues/12

here I implemented a basic benchmarking infrastructure using ASV for comparing the `parallel` and `normal` implementations of the `betweenness_centrality` function. I couldn’t figure out how to run it for different number of nodes and edge probabilities, we would probably have to define our own benchmarking classes for that.

The steps to run the benchmarks are in README.md (result ss) :
<img width="1440" alt="Screenshot 2023-10-24 at 10 09 47 PM" src="https://github.com/networkx/nx-parallel/assets/91629733/8d9bb0f6-f3af-4de6-9193-78aea8cb79d3">

Please give your feedback to better it.

Thank you :)

References: ASV docs, networkx benchmarking, numpy benchmarking