### PR TITLE
Sync up min python version with networkx main repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       # fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "An experimental parallel backend for NetworkX"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 keywords = ["networkx", "algorithms", "parallel"]
 license = {text = "BSD-3-Clause"}
 classifiers = [
@@ -38,7 +38,7 @@ py-modules = []
 
 [tool.ruff]
 line-length = 88
-target-version = 'py311'
+target-version = 'py310'
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ['I', 'F403']


### PR DESCRIPTION
Python 3.11 seems to be a blocker to build networkx docs with all the dependencies in the doc building pipeline https://github.com/networkx/networkx/pull/7220