### PR TITLE
MAINT : added `default_benchmark_timeout` to `asv.conf.json`

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -16,5 +16,6 @@
     "env_dir": "env",
     "results_dir": "results",
     "html_dir": "html",
-    "build_cache_size": 8
+    "build_cache_size": 8,
+    "default_benchmark_timeout": 1200
 }

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -17,5 +17,5 @@
     "results_dir": "results",
     "html_dir": "html",
     "build_cache_size": 8,
-    "default_benchmark_timeout": 1200
+    "default_benchmark_timeout": 1200,
 }


### PR DESCRIPTION
For 800 node graphs, the benchmarks fail and give a timeout error(60.0 s).