### PR TITLE
BUG : included `_nx_parallel` in packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ parallel = "nx_parallel.interface:Dispatcher"
 [project.entry-points."networkx.backend_info"]
 parallel = "_nx_parallel:get_info"
 
-[tool.setuptools]
-py-modules = []
+[tool.hatch.build.targets.wheel]
+packages = ["_nx_parallel", "nx_parallel",]
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
After merging [this recent PR](https://github.com/networkx/nx-parallel/pull/53), the following error was showing up [at 2 places](https://output.circle-artifacts.com/output/job/52172818-196d-4f17-83cb-a194dd0dfe12/artifacts/0/doc/build/html/search.html?q=_nx_parallel) in this [recent build](https://github.com/networkx/networkx/actions/runs/8311974473/job/22746322471) (ref. ss)

```
/home/circleci/project/networkx/utils/backends.py:143: RuntimeWarning: Error encountered when loading info for backend parallel: No module named '_nx_parallel'
  backend_info = _get_backends("networkx.backend_info", load_and_call=True)
```
<img width="1440" alt="Screenshot 2024-03-19 at 8 52 16 PM" src="https://github.com/networkx/nx-parallel/assets/91629733/939b4499-9cbe-4b5a-ae07-cbe913d94a7b">
<img width="1440" alt="Screenshot 2024-03-19 at 8 52 27 PM" src="https://github.com/networkx/nx-parallel/assets/91629733/ebcbd84c-d7c6-4c3a-bb06-31316dedd478">


and earlier this was showing up at the same places

```
/opt/hostedtoolcache/Python/3.11.8/x64/lib/python3.11/site-packages/networkx/utils/backends.py:143: RuntimeWarning: Error encountered when loading info for backend parallel: partially initialized module 'networkx' has no attribute '_dispatchable' (most likely due to a circular import)
  backend_info = _get_backends("networkx.backend_info", load_and_call=True)
```
ref. https://networkx.org/documentation/latest/search.html?q=RuntimeWarning

I have explicitly mentioned `_nx_parallel` in packages in `pyproject.toml` in this PR (ref. https://hatch.pypa.io/latest/config/build/#packages)

And now `_nx_parallel` is appearing in the wheel(locally):

```
(venv) (base) aditi@Aditis-MacBook-Air nx-parallel % hatch build
────────────────────────────────────────────────────────────────────────── sdist ──────────────────────────────────────────────────────────────────────────
dist/nx_parallel-0.2rc0.dev0.tar.gz
────────────────────────────────────────────────────────────────────────── wheel ──────────────────────────────────────────────────────────────────────────
dist/nx_parallel-0.2rc0.dev0-py3-none-any.whl
(venv) (base) aditi@Aditis-MacBook-Air nx-parallel % cd dist
(venv) (base) aditi@Aditis-MacBook-Air dist % ls
nx_parallel-0.2rc0.dev0-py3-none-any.whl	nx_parallel-0.2rc0.dev0.tar.gz
(venv) (base) aditi@Aditis-MacBook-Air dist % unzip nx_parallel-0.2rc0.dev0-py3-none-any.whl

Archive:  nx_parallel-0.2rc0.dev0-py3-none-any.whl
  inflating: _nx_parallel/__init__.py  
  inflating: nx_parallel/__init__.py  
  inflating: nx_parallel/interface.py  
  inflating: nx_parallel/algorithms/__init__.py  
  inflating: nx_parallel/algorithms/cluster.py  
  inflating: nx_parallel/algorithms/efficiency_measures.py  
  inflating: nx_parallel/algorithms/isolate.py  
  inflating: nx_parallel/algorithms/tournament.py  
  inflating: nx_parallel/algorithms/vitality.py  
  inflating: nx_parallel/algorithms/bipartite/__init__.py  
  inflating: nx_parallel/algorithms/bipartite/redundancy.py  
  inflating: nx_parallel/algorithms/centrality/__init__.py  
  inflating: nx_parallel/algorithms/centrality/betweenness.py  
  inflating: nx_parallel/algorithms/shortest_paths/__init__.py  
  inflating: nx_parallel/algorithms/shortest_paths/weighted.py  
  inflating: nx_parallel/utils/__init__.py  
  inflating: nx_parallel/utils/chunk.py  
  inflating: nx_parallel-0.2rc0.dev0.dist-info/METADATA  
  inflating: nx_parallel-0.2rc0.dev0.dist-info/WHEEL  
  inflating: nx_parallel-0.2rc0.dev0.dist-info/entry_points.txt  
  inflating: nx_parallel-0.2rc0.dev0.dist-info/RECORD  
```

Also, I tried building the networkx docs locally using this PR's branch of my forked nx-parallel repo and [this](https://github.com/Schefflera-Arboricola/networkx/tree/exp_config_change) branch of my forked networkx repo. And the ModuleNotFound error was not showing up(ref. ss):
<img width="1440" alt="Screenshot 2024-03-17 at 9 07 26 PM" src="https://github.com/networkx/nx-parallel/assets/91629733/160eac15-9366-4706-b108-7c5130dfb056">
<img width="1440" alt="Screenshot 2024-03-17 at 9 07 36 PM" src="https://github.com/networkx/nx-parallel/assets/91629733/b901b3b4-cdf5-4c7d-bfc8-0d7b7c00474a">

but I wasn't able to see nx-parallel info in the "additional backend implementation" box locally(ref. ss) :
<img width="1440" alt="Screenshot 2024-03-18 at 8 42 31 AM" src="https://github.com/networkx/nx-parallel/assets/91629733/88bfe0dd-07cc-4df8-878a-093ee6c73313">


Thank you :)

