### PR TITLE
Renaming functions with a different name while dispatching

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,21 @@ nx-parallel is a NetworkX backend that uses joblib for parallelization. This pro
 - [closeness_vitality](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/vitality.py#L9)
 - [is_reachable](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/tournament.py#L10)
 - [tournament_is_strongly_connected](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/tournament.py#L54)
+- [all_pairs_node_connectivity](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/connectivity/connectivity.py#L17)
+- [approximate_all_pairs_node_connectivity](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/approximation/connectivity.py#L12)
 - [betweenness_centrality](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/centrality/betweenness.py#L16)
 - [node_redundancy](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/bipartite/redundancy.py#L11)
-- [all_pairs_bellman_ford_path](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/weighted.py#L16)
-- [johnson](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/weighted.py#L59)
+- [all_pairs_dijkstra](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/weighted.py#L28)
+- [all_pairs_dijkstra_path_length](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/weighted.py#L71)
+- [all_pairs_dijkstra_path](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/weighted.py#L121)
+- [all_pairs_bellman_ford_path_length](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/weighted.py#L164)
+- [all_pairs_bellman_ford_path](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/weighted.py#L209)
+- [johnson](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/weighted.py#L252)
+- [all_pairs_all_shortest_paths](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/generic.py#L10)
+- [all_pairs_shortest_path_length](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/unweighted.py#L18)
+- [all_pairs_shortest_path](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/unweighted.py#L62)
+- [chunks](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/utils/chunk.py#L7)
+- [cpu_count](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/utils/chunk.py#L17)
 
 <details>
 <summary>Script used to generate the above list</summary>
@@ -53,7 +64,7 @@ nxp.betweenness_centrality(H)
 
 ### Notes
 
-1. Some functions in networkx have the same name but different implementations, so to avoid these name conflicts we differentiate them by the `name` parameter in `_dispatchable` at the time of dispatching (ref. [docs](https://networkx.org/documentation/latest/reference/generated/networkx.utils.backends._dispatchable.html#dispatchable)). So, mentioning either the full path of the implementation or the `name` parameter is recommended. For example:
+1. Some functions in networkx have the same name but different implementations, so to avoid these name conflicts we differentiate them by the `name` parameter in `_dispatchable` at the time of dispatching (ref. [docs](https://networkx.org/documentation/latest/reference/generated/networkx.utils.backends._dispatchable.html#dispatchable)). So, `method 4` is not recommended. Instead, mentioning either the full path of the algorithm or the `name` parameter is recommended. For example:
 
    ```.py
    # using full path

--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ nx-parallel is a NetworkX backend that uses joblib for parallelization. This pro
 - [all_pairs_all_shortest_paths](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/generic.py#L10)
 - [all_pairs_shortest_path_length](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/unweighted.py#L18)
 - [all_pairs_shortest_path](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/unweighted.py#L62)
-- [chunks](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/utils/chunk.py#L7)
-- [cpu_count](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/utils/chunk.py#L17)
 
 <details>
 <summary>Script used to generate the above list</summary>

--- a/nx_parallel/algorithms/approximation/connectivity.py
+++ b/nx_parallel/algorithms/approximation/connectivity.py
@@ -5,17 +5,24 @@ from networkx.algorithms.approximation.connectivity import local_node_connectivi
 import nx_parallel as nxp
 
 __all__ = [
-    "all_pairs_node_connectivity",
+    "approximate_all_pairs_node_connectivity",
 ]
 
 
-def all_pairs_node_connectivity(G, nbunch=None, cutoff=None, get_chunks="chunks"):
+def approximate_all_pairs_node_connectivity(
+    G, nbunch=None, cutoff=None, get_chunks="chunks"
+):
     """The parallel implementation first divides the a list of all permutation (in case
     of directed graphs) and combinations (in case of undirected graphs) of `nbunch`
     into chunks and then creates a generator to lazily compute the local node
     connectivities for each chunk, and then employs joblib's `Parallel` function to
     execute these computations in parallel across all available CPU cores. At the end,
     the results are aggregated into a single dictionary and returned.
+
+    Note, this function uses the name `approximate_all_pairs_node_connectivity` while
+    dispatching to the backend in=mplementation. So, `nxp.all_pairs_node_connectivity`
+    will run the parallel implementation of `all_pairs_node_connectivity` present in the
+    `connectivity/connectivity`. Use `nxp.approximate_all_pairs_node_connectivity` instead.
 
     Parameters
     ------------

--- a/nx_parallel/algorithms/tournament.py
+++ b/nx_parallel/algorithms/tournament.py
@@ -3,7 +3,7 @@ import nx_parallel as nxp
 
 __all__ = [
     "is_reachable",
-    "is_strongly_connected",
+    "tournament_is_strongly_connected",
 ]
 
 
@@ -51,10 +51,14 @@ def is_reachable(G, s, t):
     return all(results)
 
 
-def is_strongly_connected(G):
+def tournament_is_strongly_connected(G):
     """The parallel computation is implemented by dividing the
     nodes into chunks and then checking whether each node is reachable from each
     other node in parallel.
+
+    Note, this function uses the name `tournament_is_strongly_connected` while
+    dispatching to the backend in=mplementation. So, `nxp.tournament.is_strongly_connected`
+    will result in an error. Use `nxp.tournament_is_strongly_connected` instead.
 
     networkx.tournament.is_strongly_connected : https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.tournament.is_strongly_connected.html#networkx.algorithms.tournament.is_strongly_connected
     """

--- a/nx_parallel/interface.py
+++ b/nx_parallel/interface.py
@@ -15,10 +15,13 @@ from nx_parallel.algorithms.shortest_paths.unweighted import (
 )
 from nx_parallel.algorithms.efficiency_measures import local_efficiency
 from nx_parallel.algorithms.isolate import number_of_isolates
-from nx_parallel.algorithms import tournament
+from nx_parallel.algorithms.tournament import (
+    is_reachable,
+    tournament_is_strongly_connected,
+)
 from nx_parallel.algorithms.vitality import closeness_vitality
 from nx_parallel.algorithms.approximation.connectivity import (
-    all_pairs_node_connectivity,
+    approximate_all_pairs_node_connectivity,
 )
 from nx_parallel.algorithms.connectivity import connectivity
 from nx_parallel.algorithms.cluster import square_clustering
@@ -55,8 +58,8 @@ class Dispatcher:
     closeness_vitality = closeness_vitality
 
     # Tournament
-    is_reachable = tournament.is_reachable
-    tournament_is_strongly_connected = tournament.is_strongly_connected
+    is_reachable = is_reachable
+    tournament_is_strongly_connected = tournament_is_strongly_connected
 
     # Centrality
     betweenness_centrality = betweenness_centrality
@@ -83,7 +86,7 @@ class Dispatcher:
     all_pairs_shortest_path_length = all_pairs_shortest_path_length
 
     # Approximation
-    approximate_all_pairs_node_connectivity = all_pairs_node_connectivity
+    approximate_all_pairs_node_connectivity = approximate_all_pairs_node_connectivity
 
     # Connectivity
     all_pairs_node_connectivity = connectivity.all_pairs_node_connectivity


### PR DESCRIPTION
Reverting the change made in PR https://github.com/networkx/nx-parallel/pull/32
The changes made in the above PR would let the user do something like `nxp.tournament.is_strongly_connected(H)` for functions with a different `name` in `_dispachable` decorator(ref PR’s first comment for more) but it breaks the way we currently create the `get_info` function and how we automatically generate the algorithms list in the README.md. Let me know what you think.
