### PR TITLE
Test on Python 3.13-dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       # fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13-dev"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Python 3.13.0rc2 was made available recently: https://github.com/actions/python-versions/releases/tag/3.13.0-rc.2-10765745850