### PR TITLE
Handling empty graph edge-case for `betweenness_centrality` and `edge_betweenness_centrality`

### DIFF
--- a/_nx_parallel/__init__.py
+++ b/_nx_parallel/__init__.py
@@ -98,7 +98,7 @@ def get_info():
                 },
             },
             "edge_betweenness_centrality": {
-                "url": "https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/centrality/betweenness.py#L96",
+                "url": "https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/centrality/betweenness.py#L99",
                 "additional_docs": "The parallel computation is implemented by dividing the nodes into chunks and computing edge betweenness centrality for each chunk concurrently.",
                 "additional_parameters": {
                     'get_chunks : str, function (default = "chunks")': "A function that takes in a list of all the nodes as input and returns an iterable `node_chunks`. The default chunking is done by slicing the `nodes` into `n_jobs` number of chunks."

--- a/nx_parallel/algorithms/centrality/betweenness.py
+++ b/nx_parallel/algorithms/centrality/betweenness.py
@@ -61,9 +61,6 @@ def betweenness_centrality(
         for chunk in node_chunks
     )
 
-    if not bt_cs:
-        return {}
-
     # Reducing partial solution
     bt_c = bt_cs[0]
     for bt in bt_cs[1:]:
@@ -136,9 +133,6 @@ def edge_betweenness_centrality(
         delayed(_edge_betweenness_centrality_node_subset)(G, chunk, weight)
         for chunk in node_chunks
     )
-
-    if not bt_cs:
-        return {}
 
     # Reducing partial solution
     bt_c = bt_cs[0]

--- a/nx_parallel/algorithms/centrality/betweenness.py
+++ b/nx_parallel/algorithms/centrality/betweenness.py
@@ -41,6 +41,9 @@ def betweenness_centrality(
     if hasattr(G, "graph_object"):
         G = G.graph_object
 
+    if not G:
+        return {}
+
     if k is None:
         nodes = G.nodes
     else:
@@ -110,6 +113,9 @@ def edge_betweenness_centrality(
     """
     if hasattr(G, "graph_object"):
         G = G.graph_object
+
+    if not G:
+        return {}
 
     if k is None:
         nodes = G.nodes


### PR DESCRIPTION
This PR addresses issue #99 by adding a condition to return an empty dictionary `{}` for empty graphs in the following functions:

1. `betweenness_centrality`
2. `edge_betweenness_centrality`

I am planning to implement similar checks for other functions as well.
Let me know if I should tweak it any further!