### PR TITLE
Updating betweeness_centrality to be in accordance with networkx implementation

### DIFF
--- a/_nx_parallel/__init__.py
+++ b/_nx_parallel/__init__.py
@@ -98,7 +98,7 @@ def get_info():
                 },
             },
             "edge_betweenness_centrality": {
-                "url": "https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/centrality/betweenness.py#L99",
+                "url": "https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/centrality/betweenness.py#L109",
                 "additional_docs": "The parallel computation is implemented by dividing the nodes into chunks and computing edge betweenness centrality for each chunk concurrently.",
                 "additional_parameters": {
                     'get_chunks : str, function (default = "chunks")': "A function that takes in a list of all the nodes as input and returns an iterable `node_chunks`. The default chunking is done by slicing the `nodes` into `n_jobs` number of chunks."

--- a/nx_parallel/algorithms/centrality/betweenness.py
+++ b/nx_parallel/algorithms/centrality/betweenness.py
@@ -44,6 +44,16 @@ def betweenness_centrality(
     if not G:
         return {}
 
+    if k is not None:
+        if k < 0:
+            raise ValueError("k cannot be negative")
+        if k == 0:
+            raise ZeroDivisionError("k cannot be zero")
+        if k > len(G):
+            raise ValueError(f"k cannot be larger than the total nodes in G={len(G)}")
+        if k == len(G):
+            k = None
+
     if k is None:
         nodes = G.nodes
     else:
@@ -116,6 +126,16 @@ def edge_betweenness_centrality(
 
     if not G:
         return {}
+
+    if k is not None:
+        if k < 0:
+            raise ValueError("k cannot be negative")
+        if k == 0:
+            raise ZeroDivisionError("k cannot be zero")
+        if k > len(G):
+            raise ValueError(f"k cannot be larger than the total nodes in G={len(G)}")
+        if k == len(G):
+            k = None
 
     if k is None:
         nodes = G.nodes

--- a/nx_parallel/algorithms/centrality/betweenness.py
+++ b/nx_parallel/algorithms/centrality/betweenness.py
@@ -127,16 +127,6 @@ def edge_betweenness_centrality(
     if not G:
         return {}
 
-    if k is not None:
-        if k < 0:
-            raise ValueError("k cannot be negative")
-        if k == 0:
-            raise ZeroDivisionError("k cannot be zero")
-        if k > len(G):
-            raise ValueError(f"k cannot be larger than the total nodes in G={len(G)}")
-        if k == len(G):
-            k = None
-
     if k is None:
         nodes = G.nodes
     else:


### PR DESCRIPTION
This PR addresses two test failures in betweenness centrality when using nx-parallel as the backend for NetworkX tests:
Solving issue: #101 

- In the test_sample_from_P3 test, the central node in a 3-node path graph showed a betweenness value of 0.6666... when it should be exactly 1.0.
- In the test_k_out_of_bounds_raises test, when k=4 for a 4-node cycle graph, nx-parallel calculated values of 0.125 instead of the expected 0.16666... that NetworkX produces.

The issues occurred in the case where k was equal to the number of nodes in the Graph. While nx-parallel was treating k=len(G) as a separate sample case, NetworkX treated it as being similar to k=None (a full population computation).

The fix adds a simple check to both betweenness_centrality and edge_betweenness_centrality functions:

```python
if k == len(G):
    k = None
```
This ensures that when k equals the graph size, it's treated as a full calculation rather than a sampling case, making nx-parallel's normalization consistent with NetworkX's implementation.

I've also added errors for the different cases with appropriate messages where k is less than 0, equal to 0, or greater than the number of nodes in the Graph.
```python
if k is not None:
        if k < 0:
            raise ValueError("k cannot be negative")
        if k == 0:
            raise ZeroDivisionError("k cannot be zero")
        if k > len(G):
            raise ValueError(f"k cannot be larger than the total nodes in G={len(G)}")
```
Kindly let me know if there are any changes required in this and if I have missed out on anything. Thank You!