### PR TITLE
Refactor get_all_functions to use inspect.signature instead of inspect.getfullargspe

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,11 +121,12 @@ The default chunking in nx-parallel is done by slicing the list of nodes (or edg
 - The algorithm that you are considering to add to nx-parallel should be in the main networkx repository and it should have the `_dispatchable` decorator. If not, you can consider adding a sequential implementation in networkx first.
 - check-list for adding a new function:
   - [ ] Add the parallel implementation(make sure API doesn't break), the file structure should be the same as that in networkx.
-  - [ ] add the function to the `BackendInterface` class in [interface.py](./nx_parallel/interface.py) (take care of the `name` parameter in `_dispatchable` (ref. [docs](https://networkx.org/documentation/latest/reference/backends.html)))
+  - [ ] Include the `get_chunks` additional parameter. Currently, all algorithms in nx-parallel offer the user to pass their own custom chunks. Unless it is impossible to chunk, please do include this additional parameter.
+  - [ ] add the function to the `ALGORITHMS` list in [interface.py](./nx_parallel/interface.py). Take care of the `name` parameter in `_dispatchable` for the algorithms with same name but different implementations. The `name` parameter is used distinguish such algorithms in a single namespace. (ref. [docs](https://networkx.org/documentation/latest/reference/backends.html)))
   - [ ] update the `__init__.py` files accordingly
   - [ ] docstring following the above format
-  - [ ] run the [timing script](./timing/timing_individual_function.py) to get the performance heatmap
-  - [ ] add additional test(if any)
-  - [ ] add benchmark(s) for the new function(ref. the README in benchmarks folder for more details)
+  - [ ] add additional test, if needed. The smoke tests for the additional parameter `get_chunks` are done [here](https://github.com/networkx/nx-parallel/blob/main/nx_parallel/tests/test_get_chunks.py) together for all the algorithms.
+  - [ ] run the [timing script](./timing/timing_individual_function.py) to get the performance heatmap (ref. [Issue#51](https://github.com/networkx/nx-parallel/issues/51))
+  - [ ] add benchmark(s) for the new function(ref. the README in `benchmarks` folder for more details)
 
 Happy contributing! 🎉

--- a/nx_parallel/tests/test_get_chunks.py
+++ b/nx_parallel/tests/test_get_chunks.py
@@ -89,7 +89,7 @@ def test_get_chunks():
                         assert c1 == c2
                 else:
                     if func in chk_dict_vals:
-                        for key in c1.keys():
+                        for key in c1:
                             if not math.isclose(c1[key], c2[key], abs_tol=1e-16):
                                 raise ValueError(
                                     f"Values for key '{key}' differ: {c1[key]} != {c2[key]}"

--- a/nx_parallel/tests/test_get_chunks.py
+++ b/nx_parallel/tests/test_get_chunks.py
@@ -10,34 +10,62 @@ import networkx as nx
 import nx_parallel as nxp
 
 
-def get_all_funcs_with_args(package_name="nx_parallel"):
-    """Returns a dict keyed by function names to a list of
-    the function's args names, for all the functions in
-    the package `package_name`.
-    """
-    package = importlib.import_module(package_name)
-    funcs_with_args = {}
-
-    for name, obj in inspect.getmembers(package, inspect.isfunction):
-        if not name.startswith("_"):
-            signature = inspect.signature(obj)
-            arguments = [
-                param.name
-                for param in signature.parameters.values()
-                if param.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
-            ]
-            funcs_with_args[name] = arguments
-    return funcs_with_args
-
-
 def get_functions_with_get_chunks():
     """Returns a list of function names with the `get_chunks` kwarg."""
+
+    def get_all_funcs_with_args(package_name="nx_parallel"):
+        """Returns a dict keyed by function names to a list of
+        the function's args names, for all the functions in
+        the package `package_name`.
+        """
+        package = importlib.import_module(package_name)
+        funcs_with_args = {}
+
+        for name, obj in inspect.getmembers(package, inspect.isfunction):
+            if not name.startswith("_"):
+                signature = inspect.signature(obj)
+                arguments = [
+                    param.name
+                    for param in signature.parameters.values()
+                    if param.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+                ]
+                funcs_with_args[name] = arguments
+        return funcs_with_args
+
     all_funcs = get_all_funcs_with_args()
     get_chunks_funcs = []
     for func in all_funcs:
         if "get_chunks" in all_funcs[func]:
             get_chunks_funcs.append(func)
     return get_chunks_funcs
+
+
+def test_get_functions_with_get_chunks():
+    # TODO: Instead of `expected` use ALGORTHMS from interface.py
+    # take care of functions like `connectivity.all_pairs_node_connectivity`
+    expected = {
+        "all_pairs_all_shortest_paths",
+        "all_pairs_bellman_ford_path",
+        "all_pairs_bellman_ford_path_length",
+        "all_pairs_dijkstra",
+        "all_pairs_dijkstra_path",
+        "all_pairs_dijkstra_path_length",
+        "all_pairs_node_connectivity",
+        "all_pairs_shortest_path",
+        "all_pairs_shortest_path_length",
+        "approximate_all_pairs_node_connectivity",
+        "betweenness_centrality",
+        "closeness_vitality",
+        "edge_betweenness_centrality",
+        "is_reachable",
+        "johnson",
+        "local_efficiency",
+        "node_redundancy",
+        "number_of_isolates",
+        "square_clustering",
+        "tournament_is_strongly_connected",
+    }
+    assert set(get_functions_with_get_chunks()) == expected
 
 
 def test_get_chunks():

--- a/nx_parallel/tests/test_get_chunks.py
+++ b/nx_parallel/tests/test_get_chunks.py
@@ -10,31 +10,31 @@ import networkx as nx
 import nx_parallel as nxp
 
 
-def get_all_functions_kwargs(package_name="nx_parallel"):
-    """Returns a dict keyed by function names to its positional-or-keyword arguments.
+def get_all_function_arguments(package_name="nx_parallel"):
+    """Returns a dict keyed by function names to its arguments.
 
     This function constructs a dictionary keyed by the function
     names in the package `package_name` to dictionaries containing
-    the function's positional-or-keyword arguments.
+    the function's arguments.
     """
     package = importlib.import_module(package_name)
-    all_funcs_kwargs = {}
+    all_funcs_arguments = {}
 
     for name, obj in inspect.getmembers(package, inspect.isfunction):
         if not name.startswith("_"):
             signature = inspect.signature(obj)
-            kwargs = [
+            arguments = [
                 param.name
                 for param in signature.parameters.values()
                 if param.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
             ]
-            all_funcs_kwargs[name] = kwargs
-    return all_funcs_kwargs
+            all_funcs_arguments[name] = arguments
+    return all_funcs_arguments
 
 
 def get_functions_with_get_chunks():
     """Returns a list of function names with the `get_chunks` kwarg."""
-    all_funcs_kwargs = get_all_functions_kwargs()
+    all_funcs_kwargs = get_all_function_arguments()
     get_chunks_funcs = []
     for func in all_funcs_kwargs:
         if "get_chunks" in all_funcs_kwargs[func]:
@@ -81,19 +81,13 @@ def test_get_chunks():
                     c1, c2 = dict(c1), dict(c2)
                     if func in chk_dict_vals:
                         for key in c1:
-                            if not math.isclose(c1[key], c2[key], abs_tol=1e-16):
-                                raise ValueError(
-                                    f"Values for key '{key}' differ: {c1[key]} != {c2[key]}"
-                                )
+                            assert math.isclose(c1[key], c2[key], abs_tol=1e-16)
                     else:
                         assert c1 == c2
                 else:
                     if func in chk_dict_vals:
                         for key in c1:
-                            if not math.isclose(c1[key], c2[key], abs_tol=1e-16):
-                                raise ValueError(
-                                    f"Values for key '{key}' differ: {c1[key]} != {c2[key]}"
-                                )
+                            assert math.isclose(c1[key], c2[key], abs_tol=1e-16)
                     else:
                         if isinstance(c1, float):
                             assert math.isclose(c1, c2, abs_tol=1e-16)

--- a/nx_parallel/tests/test_get_chunks.py
+++ b/nx_parallel/tests/test_get_chunks.py
@@ -10,15 +10,13 @@ import networkx as nx
 import nx_parallel as nxp
 
 
-def get_all_function_arguments(package_name="nx_parallel"):
-    """Returns a dict keyed by function names to its arguments.
-
-    This function constructs a dictionary keyed by the function
-    names in the package `package_name` to dictionaries containing
-    the function's arguments.
+def get_all_funcs_with_args(package_name="nx_parallel"):
+    """Returns a dict keyed by function names to a list of
+    the function's args names, for all the functions in
+    the package `package_name`.
     """
     package = importlib.import_module(package_name)
-    all_funcs_arguments = {}
+    funcs_with_args = {}
 
     for name, obj in inspect.getmembers(package, inspect.isfunction):
         if not name.startswith("_"):
@@ -28,16 +26,16 @@ def get_all_function_arguments(package_name="nx_parallel"):
                 for param in signature.parameters.values()
                 if param.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
             ]
-            all_funcs_arguments[name] = arguments
-    return all_funcs_arguments
+            funcs_with_args[name] = arguments
+    return funcs_with_args
 
 
 def get_functions_with_get_chunks():
     """Returns a list of function names with the `get_chunks` kwarg."""
-    all_funcs_kwargs = get_all_function_arguments()
+    all_funcs = get_all_funcs_with_args()
     get_chunks_funcs = []
-    for func in all_funcs_kwargs:
-        if "get_chunks" in all_funcs_kwargs[func]:
+    for func in all_funcs:
+        if "get_chunks" in all_funcs[func]:
             get_chunks_funcs.append(func)
     return get_chunks_funcs
 


### PR DESCRIPTION
This PR addresses issue #94

Changes made : 
1. Replaced `inspect.getfullargspec()` with `inspect.signature()` for reporting the signature of the original function and not that of wrapped.

2. Updated the assertion logic in the `test_get_chunks` for `chk_dict_vals` to iterate over graph edges instead of nodes since `chk_dict_vals` consists of functions that deals with edges between the nodes and not the nodes themselves.