### PR TITLE
correctly pass n_jobs as n_chunks to chunks()

### DIFF
--- a/_nx_parallel/__init__.py
+++ b/_nx_parallel/__init__.py
@@ -21,14 +21,14 @@ def get_info():
                 },
             },
             "all_pairs_bellman_ford_path": {
-                "url": "https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/weighted.py#L212",
+                "url": "https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/weighted.py#L208",
                 "additional_docs": "The parallel implementation first divides the nodes into chunks and then creates a generator to lazily compute shortest paths for each node_chunk, and then employs joblib's `Parallel` function to execute these computations in parallel across `n_jobs` number of CPU cores.",
                 "additional_parameters": {
                     'get_chunks : str, function (default = "chunks")': "A function that takes in an iterable of all the nodes as input and returns an iterable `node_chunks`. The default chunking is done by slicing the `G.nodes` into `n_jobs` number of chunks."
                 },
             },
             "all_pairs_bellman_ford_path_length": {
-                "url": "https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/weighted.py#L168",
+                "url": "https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/weighted.py#L165",
                 "additional_docs": "The parallel implementation first divides the nodes into chunks and then creates a generator to lazily compute shortest paths lengths for each node in `node_chunk`, and then employs joblib's `Parallel` function to execute these computations in parallel across `n_jobs` number of CPU cores.",
                 "additional_parameters": {
                     'get_chunks : str, function (default = "chunks")': "A function that takes in an iterable of all the nodes as input and returns an iterable `node_chunks`. The default chunking is done by slicing the `G.nodes` into `n_jobs` number of chunks."
@@ -42,14 +42,14 @@ def get_info():
                 },
             },
             "all_pairs_dijkstra_path": {
-                "url": "https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/weighted.py#L124",
+                "url": "https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/weighted.py#L122",
                 "additional_docs": "The parallel implementation first divides the nodes into chunks and then creates a generator to lazily compute shortest paths for each `node_chunk`, and then employs joblib's `Parallel` function to execute these computations in parallel across `n_jobs` number of CPU cores.",
                 "additional_parameters": {
                     'get_chunks : str, function (default = "chunks")': "A function that takes in an iterable of all the nodes as input and returns an iterable `node_chunks`. The default chunking is done by slicing the `G.nodes` into `n_jobs` number of chunks."
                 },
             },
             "all_pairs_dijkstra_path_length": {
-                "url": "https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/weighted.py#L73",
+                "url": "https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/weighted.py#L72",
                 "additional_docs": "The parallel implementation first divides the nodes into chunks and then creates a generator to lazily compute shortest paths lengths for each node in `node_chunk`, and then employs joblib's `Parallel` function to execute these computations in parallel across `n_jobs` number of CPU cores.",
                 "additional_parameters": {
                     'get_chunks : str, function (default = "chunks")': "A function that takes in an iterable of all the nodes as input and returns an iterable `node_chunks`. The default chunking is done by slicing the `G.nodes` into `n_jobs` number of chunks."
@@ -63,7 +63,7 @@ def get_info():
                 },
             },
             "all_pairs_shortest_path": {
-                "url": "https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/unweighted.py#L63",
+                "url": "https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/unweighted.py#L62",
                 "additional_docs": "The parallel implementation first divides the nodes into chunks and then creates a generator to lazily compute shortest paths for each `node_chunk`, and then employs joblib's `Parallel` function to execute these computations in parallel across `n_jobs` number of CPU cores.",
                 "additional_parameters": {
                     'get_chunks : str, function (default = "chunks")': "A function that takes in an iterable of all the nodes as input and returns an iterable `node_chunks`. The default chunking is done by slicing the `G.nodes` into `n_jobs` number of chunks."
@@ -112,7 +112,7 @@ def get_info():
                 },
             },
             "johnson": {
-                "url": "https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/weighted.py#L256",
+                "url": "https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/shortest_paths/weighted.py#L251",
                 "additional_docs": "The parallel computation is implemented by dividing the nodes into chunks and computing the shortest paths using Johnson's Algorithm for each chunk in parallel.",
                 "additional_parameters": {
                     'get_chunks : str, function (default = "chunks")': "A function that takes in an iterable of all the nodes as input and returns an iterable `node_chunks`. The default chunking is done by slicing the `G.nodes` into `n_jobs` number of chunks."
@@ -147,7 +147,7 @@ def get_info():
                 },
             },
             "tournament_is_strongly_connected": {
-                "url": "https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/tournament.py#L59",
+                "url": "https://github.com/networkx/nx-parallel/blob/main/nx_parallel/algorithms/tournament.py#L58",
                 "additional_docs": "The parallel computation is implemented by dividing the nodes into chunks and then checking whether each node is reachable from each other node in parallel.",
                 "additional_parameters": {
                     'get_chunks : str, function (default = "chunks")': "A function that takes in a list of all the nodes as input and returns an iterable `node_chunks`. The default chunking is done by slicing the `nodes` into `n_jobs` number of chunks."

--- a/nx_parallel/algorithms/approximation/connectivity.py
+++ b/nx_parallel/algorithms/approximation/connectivity.py
@@ -63,8 +63,7 @@ def approximate_all_pairs_node_connectivity(
     pairs = list(iter_func(nbunch, 2))
     n_jobs = nxp.get_n_jobs()
     if get_chunks == "chunks":
-        num_in_chunk = max(min(len(pairs) // n_jobs, 10), 1)
-        pairs_chunks = nxp.chunks(pairs, num_in_chunk)
+        pairs_chunks = nxp.chunks(pairs, n_jobs)
     else:
         pairs_chunks = get_chunks(pairs)
 

--- a/nx_parallel/algorithms/bipartite/redundancy.py
+++ b/nx_parallel/algorithms/bipartite/redundancy.py
@@ -34,8 +34,7 @@ def node_redundancy(G, nodes=None, get_chunks="chunks"):
         )
     n_jobs = nxp.get_n_jobs()
     if get_chunks == "chunks":
-        num_in_chunk = max(len(nodes) // n_jobs, 1)
-        node_chunks = nxp.chunks(nodes, num_in_chunk)
+        node_chunks = nxp.chunks(nodes, n_jobs)
     else:
         node_chunks = get_chunks(nodes)
     node_redundancies = Parallel()(

--- a/nx_parallel/algorithms/cluster.py
+++ b/nx_parallel/algorithms/cluster.py
@@ -51,8 +51,7 @@ def square_clustering(G, nodes=None, get_chunks="chunks"):
     n_jobs = nxp.get_n_jobs()
 
     if get_chunks == "chunks":
-        num_in_chunk = max(len(node_iter) // n_jobs, 1)
-        node_iter_chunks = nxp.chunks(node_iter, num_in_chunk)
+        node_iter_chunks = nxp.chunks(node_iter, n_jobs)
     else:
         node_iter_chunks = get_chunks(node_iter)
 

--- a/nx_parallel/algorithms/connectivity/connectivity.py
+++ b/nx_parallel/algorithms/connectivity/connectivity.py
@@ -64,8 +64,7 @@ def all_pairs_node_connectivity(G, nbunch=None, flow_func=None, get_chunks="chun
     pairs = list(iter_func(nbunch, 2))
     n_jobs = nxp.get_n_jobs()
     if get_chunks == "chunks":
-        num_in_chunk = max(min(len(pairs) // n_jobs, 10), 1)
-        pairs_chunks = nxp.chunks(pairs, num_in_chunk)
+        pairs_chunks = nxp.chunks(pairs, n_jobs)
     else:
         pairs_chunks = get_chunks(pairs)
 

--- a/nx_parallel/algorithms/efficiency_measures.py
+++ b/nx_parallel/algorithms/efficiency_measures.py
@@ -33,8 +33,7 @@ def local_efficiency(G, get_chunks="chunks"):
     n_jobs = nxp.get_n_jobs()
 
     if get_chunks == "chunks":
-        num_in_chunk = max(len(G.nodes) // n_jobs, 1)
-        node_chunks = list(nxp.chunks(G.nodes, num_in_chunk))
+        node_chunks = list(nxp.chunks(G.nodes, n_jobs))
     else:
         node_chunks = get_chunks(G.nodes)
 

--- a/nx_parallel/algorithms/isolate.py
+++ b/nx_parallel/algorithms/isolate.py
@@ -27,8 +27,7 @@ def number_of_isolates(G, get_chunks="chunks"):
 
     isolates_list = list(nx.isolates(G))
     if get_chunks == "chunks":
-        num_in_chunk = max(len(isolates_list) // n_jobs, 1)
-        isolate_chunks = nxp.chunks(isolates_list, num_in_chunk)
+        isolate_chunks = nxp.chunks(isolates_list, n_jobs)
     else:
         isolate_chunks = get_chunks(isolates_list)
 

--- a/nx_parallel/algorithms/shortest_paths/generic.py
+++ b/nx_parallel/algorithms/shortest_paths/generic.py
@@ -44,8 +44,7 @@ def all_pairs_all_shortest_paths(
     n_jobs = nxp.get_n_jobs()
 
     if get_chunks == "chunks":
-        num_in_chunk = max(len(nodes) // n_jobs, 1)
-        node_chunks = nxp.chunks(nodes, num_in_chunk)
+        node_chunks = nxp.chunks(nodes, n_jobs)
     else:
         node_chunks = get_chunks(nodes)
 

--- a/nx_parallel/algorithms/shortest_paths/unweighted.py
+++ b/nx_parallel/algorithms/shortest_paths/unweighted.py
@@ -45,8 +45,7 @@ def all_pairs_shortest_path_length(G, cutoff=None, get_chunks="chunks"):
     n_jobs = nxp.get_n_jobs()
 
     if get_chunks == "chunks":
-        num_in_chunk = max(len(nodes) // n_jobs, 1)
-        node_chunks = nxp.chunks(nodes, num_in_chunk)
+        node_chunks = nxp.chunks(nodes, n_jobs)
     else:
         node_chunks = get_chunks(nodes)
 
@@ -89,8 +88,7 @@ def all_pairs_shortest_path(G, cutoff=None, get_chunks="chunks"):
     n_jobs = nxp.get_n_jobs()
 
     if get_chunks == "chunks":
-        num_in_chunk = max(len(nodes) // n_jobs, 1)
-        node_chunks = nxp.chunks(nodes, num_in_chunk)
+        node_chunks = nxp.chunks(nodes, n_jobs)
     else:
         node_chunks = get_chunks(nodes)
 

--- a/nx_parallel/algorithms/shortest_paths/weighted.py
+++ b/nx_parallel/algorithms/shortest_paths/weighted.py
@@ -55,8 +55,7 @@ def all_pairs_dijkstra(G, cutoff=None, weight="weight", get_chunks="chunks"):
     n_jobs = nxp.get_n_jobs()
 
     if get_chunks == "chunks":
-        num_in_chunk = max(len(nodes) // n_jobs, 1)
-        node_chunks = nxp.chunks(nodes, num_in_chunk)
+        node_chunks = nxp.chunks(nodes, n_jobs)
     else:
         node_chunks = get_chunks(nodes)
 
@@ -106,8 +105,7 @@ def all_pairs_dijkstra_path_length(
     n_jobs = nxp.get_n_jobs()
 
     if get_chunks == "chunks":
-        num_in_chunk = max(len(nodes) // n_jobs, 1)
-        node_chunks = nxp.chunks(nodes, num_in_chunk)
+        node_chunks = nxp.chunks(nodes, n_jobs)
     else:
         node_chunks = get_chunks(nodes)
 
@@ -150,8 +148,7 @@ def all_pairs_dijkstra_path(G, cutoff=None, weight="weight", get_chunks="chunks"
     n_jobs = nxp.get_n_jobs()
 
     if get_chunks == "chunks":
-        num_in_chunk = max(len(nodes) // n_jobs, 1)
-        node_chunks = nxp.chunks(nodes, num_in_chunk)
+        node_chunks = nxp.chunks(nodes, n_jobs)
     else:
         node_chunks = get_chunks(nodes)
 
@@ -194,8 +191,7 @@ def all_pairs_bellman_ford_path_length(G, weight="weight", get_chunks="chunks"):
     n_jobs = nxp.get_n_jobs()
 
     if get_chunks == "chunks":
-        num_in_chunk = max(len(nodes) // n_jobs, 1)
-        node_chunks = nxp.chunks(nodes, num_in_chunk)
+        node_chunks = nxp.chunks(nodes, n_jobs)
     else:
         node_chunks = get_chunks(nodes)
 
@@ -238,8 +234,7 @@ def all_pairs_bellman_ford_path(G, weight="weight", get_chunks="chunks"):
     n_jobs = nxp.get_n_jobs()
 
     if get_chunks == "chunks":
-        num_in_chunk = max(len(nodes) // n_jobs, 1)
-        node_chunks = nxp.chunks(nodes, num_in_chunk)
+        node_chunks = nxp.chunks(nodes, n_jobs)
     else:
         node_chunks = get_chunks(nodes)
 
@@ -292,8 +287,7 @@ def johnson(G, weight="weight", get_chunks="chunks"):
 
     n_jobs = nxp.get_n_jobs()
     if get_chunks == "chunks":
-        num_in_chunk = max(len(G.nodes) // n_jobs, 1)
-        node_chunks = nxp.chunks(G.nodes, num_in_chunk)
+        node_chunks = nxp.chunks(G.nodes, n_jobs)
     else:
         node_chunks = get_chunks(G.nodes)
 

--- a/nx_parallel/algorithms/tournament.py
+++ b/nx_parallel/algorithms/tournament.py
@@ -45,8 +45,7 @@ def is_reachable(G, s, t, get_chunks="chunks"):
     n_jobs = nxp.get_n_jobs()
 
     if get_chunks == "chunks":
-        num_in_chunk = max(len(G) // n_jobs, 1)
-        node_chunks = nxp.chunks(G, num_in_chunk)
+        node_chunks = nxp.chunks(G, n_jobs)
     else:
         node_chunks = get_chunks(G)
 
@@ -83,8 +82,7 @@ def tournament_is_strongly_connected(G, get_chunks="chunks"):
     n_jobs = nxp.get_n_jobs()
 
     if get_chunks == "chunks":
-        num_in_chunk = max(min(len(G) // n_jobs, 10), 1)
-        node_chunks = nxp.chunks(G, num_in_chunk)
+        node_chunks = nxp.chunks(G, n_jobs)
     else:
         node_chunks = get_chunks(G)
 

--- a/nx_parallel/algorithms/vitality.py
+++ b/nx_parallel/algorithms/vitality.py
@@ -39,8 +39,7 @@ def closeness_vitality(
     n_jobs = nxp.get_n_jobs()
 
     if get_chunks == "chunks":
-        num_in_chunk = max(len(G) // n_jobs, 1)
-        node_chunks = nxp.chunks(G.nodes, num_in_chunk)
+        node_chunks = nxp.chunks(G.nodes, n_jobs)
     else:
         node_chunks = get_chunks(G.nodes)
 

--- a/nx_parallel/tests/test_get_chunks.py
+++ b/nx_parallel/tests/test_get_chunks.py
@@ -44,8 +44,7 @@ def test_get_chunks():
         random.seed(42)
         random.shuffle(_nodes)
         num_chunks = nxp.get_n_jobs()
-        num_in_chunk = max(len(_nodes) // num_chunks, 1)
-        return nxp.chunks(_nodes, num_in_chunk)
+        return nxp.chunks(_nodes, num_chunks)
 
     get_chunks_funcs = get_functions_with_get_chunks()
     ignore_funcs = [


### PR DESCRIPTION
Fixes #110 

Between the two approaches:
1. Passing `n_jobs` to `chunks()`.
2. Modifying `chunks()` to accept `num_in_chunk` instead of `n_chunks`.
I chose Approach 1 — passing `n_jobs` as `n_chunks` — because this allows `chunks()` to internally compute balanced chunk sizes, handling cases where the total number of nodes cannot be evenly divided, ensuring a more flexible distribution of work.


