### PR TITLE
Remove test order dependency using context managers

### DIFF
--- a/nx_parallel/tests/test_entry_points.py
+++ b/nx_parallel/tests/test_entry_points.py
@@ -1,5 +1,4 @@
 from importlib.metadata import entry_points, EntryPoint
-import pytest
 
 
 def test_backends_ep():
@@ -16,7 +15,6 @@ def test_backend_info_ep():
     )
 
 
-@pytest.mark.order(1)
 def test_config_init():
     import networkx as nx
 

--- a/nx_parallel/utils/tests/test_chunk.py
+++ b/nx_parallel/utils/tests/test_chunk.py
@@ -4,7 +4,6 @@ import networkx as nx
 import nx_parallel as nxp
 
 
-@pytest.mark.order(2)
 def test_get_n_jobs():
     """Test for various scenarios in `get_n_jobs`."""
     # Test with no n_jobs (default)
@@ -17,17 +16,19 @@ def test_get_n_jobs():
 
         # Test with n_jobs set to negative value
         assert nxp.get_n_jobs(-1) == os.cpu_count()
-        nx.config.backends.parallel.active = False
+
+        # Test with joblib's context
         from joblib import parallel_config
 
-        parallel_config(n_jobs=3)
-        assert nxp.get_n_jobs() == 3
-        nx.config.backends.parallel.active = True
-        nx.config.backends.parallel.n_jobs = 5
-        assert nxp.get_n_jobs() == 5
-        # restore nx.config
-        nx.config.backends.parallel.active = False
-        nx.config.backends.parallel.n_jobs = None
+        with parallel_config(n_jobs=3):
+            assert nxp.get_n_jobs() == 3
+
+        # Test with nx-parallel's context
+        from _nx_parallel.config import _config
+
+        with _config(active=True, n_jobs=5):
+            assert nxp.get_n_jobs() == 5
+
     # Test with n_jobs = 0 to raise a ValueError
     try:
         nxp.get_n_jobs(0)


### PR DESCRIPTION
Handles #115 

- Replaced manual config resets with context managers to isolate config changes.
- Removed `pytest.mark.order` decorator from `test_get_n_jobs()` and `test_config_init()` since test order is no longer needed.

