### PR TITLE
Refactor ASV benchmarks to use setup functions

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -20,9 +20,12 @@ These asv benchmarks are not just good to see how parallel implementations are i
 
 ## Structure of benchmarks
 
-- Each `bench_` file corresponds to a folder/file in the [networkx/algorithms](https://github.com/networkx/networkx/tree/main/networkx/algorithms) directory in NetworkX
-- Each class inside a `bench_` file corresponds to every file in a folder(one class if it’s a file) in networkx/algorithms
-- The class name corresponds to the file name and the `x` in `bench_x` corresponds to the folder name(class name and `x` are the same if it’s a file in networkx/algorithms)
-- Each `time_` function corresponds to each function in the file.
+- Each `bench_` file corresponds to a folder/file in the [networkx/algorithms](https://github.com/networkx/networkx/tree/main/networkx/algorithms) directory in NetworkX.
+- Each class inside a `bench_` file corresponds to every file in a folder(one class if it’s a file) in networkx/algorithms.
+- The class name corresponds to the file name and the `x` in `bench_x` corresponds to the folder name(class name and `x` are the same if it’s a file in networkx/algorithms).
+- Each class has two components:
+   - One or more `time_` functions, each corresponding to a function in the file.
+   - A `setup` function, which runs once before each `time_` function is executed.
+- Shared parameters and graph utilities are defined in the file `common.py`.
 - For other folders in [networkx/networkx](https://github.com/networkx/networkx/tree/main/networkx) like `generators`, `classes`, `linalg`, `utils` etc. we can have different `bench_` files for each of them having different classes corresponding to different files in each of these folders.
 - For example: `bench_centrality.py` corresponds to `networkx/algorithms/centrality` folder in NetworkX and the `Betweenness` class inside it corresponds to the `betweenness.py` file in `networkx/algorithms/centrality` folder in NetworkX. And the `time_betweenness_centrality` function corresponds to the `betweenness_centrality` function.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -23,9 +23,9 @@ These asv benchmarks are not just good to see how parallel implementations are i
 - Each `bench_` file corresponds to a folder/file in the [networkx/algorithms](https://github.com/networkx/networkx/tree/main/networkx/algorithms) directory in NetworkX.
 - Each class inside a `bench_` file corresponds to every file in a folder(one class if it’s a file) in networkx/algorithms.
 - The class name corresponds to the file name and the `x` in `bench_x` corresponds to the folder name(class name and `x` are the same if it’s a file in networkx/algorithms).
-- Each class has two components:
-   - One or more `time_` functions, each corresponding to a function in the file.
-   - A `setup` function, which runs once before each `time_` function is executed.
+- Each benchmark class has two components:
+   1. A `setup` function, which runs once before each timing function. All code related to creating and converting graphs, or setting inputs must be included here. Code intended to be timed should not go in `setup`.
+   2. One or more `time_` functions, which benchmark the corresponding algorithm. Each `time_` function should wrap only the function call whose performance we want to measure.
 - Shared parameters and graph utilities are defined in the file `common.py`.
 - For other folders in [networkx/networkx](https://github.com/networkx/networkx/tree/main/networkx) like `generators`, `classes`, `linalg`, `utils` etc. we can have different `bench_` files for each of them having different classes corresponding to different files in each of these folders.
 - For example: `bench_centrality.py` corresponds to `networkx/algorithms/centrality` folder in NetworkX and the `Betweenness` class inside it corresponds to the `betweenness.py` file in `networkx/algorithms/centrality` folder in NetworkX. And the `time_betweenness_centrality` function corresponds to the `betweenness_centrality` function.

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -17,5 +17,5 @@
     "results_dir": "results",
     "html_dir": "html",
     "build_cache_size": 8,
-    "default_benchmark_timeout": 1200,
+    "default_benchmark_timeout": 1200
 }

--- a/benchmarks/benchmarks/bench_approximation.py
+++ b/benchmarks/benchmarks/bench_approximation.py
@@ -10,13 +10,15 @@ import nx_parallel as nxp
 
 
 class Connectivity(Benchmark):
-    params = [(backends), (num_nodes), (edge_prob)]
+    params = [backends, num_nodes, edge_prob]
     param_names = ["backend", "num_nodes", "edge_prob"]
+
+    def setup(self, backend, num_nodes, edge_prob):
+        self.G = get_cached_gnp_random_graph(num_nodes, edge_prob)
+        if backend == "parallel":
+            self.G = nxp.ParallelGraph(self.G)
 
     def time_approximate_all_pairs_node_connectivity(
         self, backend, num_nodes, edge_prob
     ):
-        G = get_cached_gnp_random_graph(num_nodes, edge_prob)
-        if backend == "parallel":
-            G = nxp.ParallelGraph(G)
-        _ = nx.algorithms.approximation.connectivity.all_pairs_node_connectivity(G)
+        _ = nx.algorithms.approximation.connectivity.all_pairs_node_connectivity(self.G)

--- a/benchmarks/benchmarks/bench_approximation.py
+++ b/benchmarks/benchmarks/bench_approximation.py
@@ -21,4 +21,4 @@ class Connectivity(Benchmark):
     def time_approximate_all_pairs_node_connectivity(
         self, backend, num_nodes, edge_prob
     ):
-        _ = nx.algorithms.approximation.connectivity.all_pairs_node_connectivity(self.G)
+        _ = nx.approximation.all_pairs_node_connectivity(self.G)

--- a/benchmarks/benchmarks/bench_bipartite.py
+++ b/benchmarks/benchmarks/bench_bipartite.py
@@ -1,6 +1,7 @@
 from .common import (
     backends,
     edge_prob,
+    seed,
     Benchmark,
 )
 import networkx as nx
@@ -11,14 +12,16 @@ m = [25, 50, 100, 200, 400]
 
 
 class Redundancy(Benchmark):
-    params = [(backends), (n), (m), (edge_prob)]
+    params = [backends, n, m, edge_prob]
     param_names = ["backend", "n", "m", "edge_prob"]
 
+    def setup(self, backend, n, m, edge_prob):
+        self.G = get_random_bipartite_graph(n, m, edge_prob)
+
     def time_node_redundancy(self, backend, n, m, edge_prob):
-        G = get_random_bipartite_graph(n, m, edge_prob)
-        _ = nx.node_redundancy(G, backend=backend)
+        _ = nx.node_redundancy(self.G, backend=backend)
 
 
-def get_random_bipartite_graph(n, m, p, seed=42, directed=False):
+def get_random_bipartite_graph(n, m, edge_prob, directed=False):
     """Ref. https://networkx.org/documentation/stable/reference/algorithms/generated/networkx.algorithms.bipartite.generators.random_graph.html"""
-    return nx.bipartite.random_graph(n, m, p, seed, directed)
+    return nx.bipartite.random_graph(n, m, edge_prob, seed, directed)

--- a/benchmarks/benchmarks/bench_centrality.py
+++ b/benchmarks/benchmarks/bench_centrality.py
@@ -9,13 +9,17 @@ import networkx as nx
 
 
 class Betweenness(Benchmark):
-    params = [(backends), (num_nodes), (edge_prob)]
+    params = [backends, num_nodes, edge_prob]
     param_names = ["backend", "num_nodes", "edge_prob"]
 
+    def setup(self, backend, num_nodes, edge_prob):
+        self.G = get_cached_gnp_random_graph(num_nodes, edge_prob)
+        self.G_weighted = get_cached_gnp_random_graph(
+            num_nodes, edge_prob, is_weighted=True
+        )
+
     def time_betweenness_centrality(self, backend, num_nodes, edge_prob):
-        G = get_cached_gnp_random_graph(num_nodes, edge_prob)
-        _ = nx.betweenness_centrality(G, backend=backend)
+        _ = nx.betweenness_centrality(self.G, backend=backend)
 
     def time_edge_betweenness_centrality(self, backend, num_nodes, edge_prob):
-        G = get_cached_gnp_random_graph(num_nodes, edge_prob, is_weighted=True)
-        _ = nx.edge_betweenness_centrality(G, backend=backend)
+        _ = nx.edge_betweenness_centrality(self.G_weighted, backend=backend)

--- a/benchmarks/benchmarks/bench_cluster.py
+++ b/benchmarks/benchmarks/bench_cluster.py
@@ -9,9 +9,11 @@ import networkx as nx
 
 
 class Cluster(Benchmark):
-    params = [(backends), (num_nodes), (edge_prob)]
+    params = [backends, num_nodes, edge_prob]
     param_names = ["backend", "num_nodes", "edge_prob"]
 
+    def setup(self, backend, num_nodes, edge_prob):
+        self.G = get_cached_gnp_random_graph(num_nodes, edge_prob)
+
     def time_square_clustering(self, backend, num_nodes, edge_prob):
-        G = get_cached_gnp_random_graph(num_nodes, edge_prob)
-        _ = nx.square_clustering(G, backend=backend)
+        _ = nx.square_clustering(self.G, backend=backend)

--- a/benchmarks/benchmarks/bench_connectivity.py
+++ b/benchmarks/benchmarks/bench_connectivity.py
@@ -19,4 +19,4 @@ class Connectivity(Benchmark):
             self.G = nxp.ParallelGraph(self.G)
 
     def time_all_pairs_node_connectivity(self, backend, num_nodes, edge_prob):
-        _ = nx.algorithms.connectivity.connectivity.all_pairs_node_connectivity(self.G)
+        _ = nx.all_pairs_node_connectivity(self.G)

--- a/benchmarks/benchmarks/bench_connectivity.py
+++ b/benchmarks/benchmarks/bench_connectivity.py
@@ -10,11 +10,13 @@ import nx_parallel as nxp
 
 
 class Connectivity(Benchmark):
-    params = [(backends), (num_nodes), (edge_prob)]
+    params = [backends, num_nodes, edge_prob]
     param_names = ["backend", "num_nodes", "edge_prob"]
 
-    def time_all_pairs_node_connectivity(self, backend, num_nodes, edge_prob):
-        G = get_cached_gnp_random_graph(num_nodes, edge_prob)
+    def setup(self, backend, num_nodes, edge_prob):
+        self.G = get_cached_gnp_random_graph(num_nodes, edge_prob)
         if backend == "parallel":
-            G = nxp.ParallelGraph(G)
-        _ = nx.algorithms.connectivity.connectivity.all_pairs_node_connectivity(G)
+            self.G = nxp.ParallelGraph(self.G)
+
+    def time_all_pairs_node_connectivity(self, backend, num_nodes, edge_prob):
+        _ = nx.algorithms.connectivity.connectivity.all_pairs_node_connectivity(self.G)

--- a/benchmarks/benchmarks/bench_efficiency_measures.py
+++ b/benchmarks/benchmarks/bench_efficiency_measures.py
@@ -9,9 +9,11 @@ import networkx as nx
 
 
 class EfficiencyMeasures(Benchmark):
-    params = [(backends), (num_nodes), (edge_prob)]
+    params = [backends, num_nodes, edge_prob]
     param_names = ["backend", "num_nodes", "edge_prob"]
 
+    def setup(self, backend, num_nodes, edge_prob):
+        self.G = get_cached_gnp_random_graph(num_nodes, edge_prob)
+
     def time_local_efficiency(self, backend, num_nodes, edge_prob):
-        G = get_cached_gnp_random_graph(num_nodes, edge_prob)
-        _ = nx.local_efficiency(G, backend=backend)
+        _ = nx.local_efficiency(self.G, backend=backend)

--- a/benchmarks/benchmarks/bench_isolate.py
+++ b/benchmarks/benchmarks/bench_isolate.py
@@ -9,9 +9,11 @@ import networkx as nx
 
 
 class Isolate(Benchmark):
-    params = [(backends), (num_nodes), (edge_prob)]
+    params = [backends, num_nodes, edge_prob]
     param_names = ["backend", "num_nodes", "edge_prob"]
 
+    def setup(self, backend, num_nodes, edge_prob):
+        self.G = get_cached_gnp_random_graph(num_nodes, edge_prob)
+
     def time_number_of_isolates(self, backend, num_nodes, edge_prob):
-        G = get_cached_gnp_random_graph(num_nodes, edge_prob)
-        _ = nx.number_of_isolates(G, backend=backend)
+        _ = nx.number_of_isolates(self.G, backend=backend)

--- a/benchmarks/benchmarks/bench_shortest_paths.py
+++ b/benchmarks/benchmarks/bench_shortest_paths.py
@@ -9,51 +9,61 @@ import networkx as nx
 
 
 class Generic(Benchmark):
-    params = [(backends), (num_nodes), (edge_prob)]
+    params = [backends, num_nodes, edge_prob]
     param_names = ["backend", "num_nodes", "edge_prob"]
 
+    def setup(self, backend, num_nodes, edge_prob):
+        self.G_weighted = get_cached_gnp_random_graph(
+            num_nodes, edge_prob, is_weighted=True
+        )
+
     def time_all_pairs_all_shortest_paths(self, backend, num_nodes, edge_prob):
-        G = get_cached_gnp_random_graph(num_nodes, edge_prob, is_weighted=True)
-        _ = dict(nx.all_pairs_all_shortest_paths(G, weight="weight", backend=backend))
+        _ = dict(
+            nx.all_pairs_all_shortest_paths(
+                self.G_weighted, weight="weight", backend=backend
+            )
+        )
 
 
 class Unweighted(Benchmark):
-    params = [(backends), (num_nodes), (edge_prob)]
+    params = [backends, num_nodes, edge_prob]
     param_names = ["backend", "num_nodes", "edge_prob"]
 
+    def setup(self, backend, num_nodes, edge_prob):
+        self.G = get_cached_gnp_random_graph(num_nodes, edge_prob)
+
     def time_all_pairs_shortest_path_length(self, backend, num_nodes, edge_prob):
-        G = get_cached_gnp_random_graph(num_nodes, edge_prob)
-        _ = dict(nx.all_pairs_shortest_path_length(G, backend=backend))
+        _ = dict(nx.all_pairs_shortest_path_length(self.G, backend=backend))
 
     def time_all_pairs_shortest_path(self, backend, num_nodes, edge_prob):
-        G = get_cached_gnp_random_graph(num_nodes, edge_prob)
-        _ = dict(nx.all_pairs_shortest_path(G, backend=backend))
+        _ = dict(nx.all_pairs_shortest_path(self.G, backend=backend))
 
 
 class Weighted(Benchmark):
-    params = [(backends), (num_nodes), (edge_prob)]
+    params = [backends, num_nodes, edge_prob]
     param_names = ["backend", "num_nodes", "edge_prob"]
 
+    def setup(self, backend, num_nodes, edge_prob):
+        self.G_weighted = get_cached_gnp_random_graph(
+            num_nodes, edge_prob, is_weighted=True
+        )
+
     def time_all_pairs_dijkstra(self, backend, num_nodes, edge_prob):
-        G = get_cached_gnp_random_graph(num_nodes, edge_prob, is_weighted=True)
-        _ = dict(nx.all_pairs_dijkstra(G, backend=backend))
+        _ = dict(nx.all_pairs_dijkstra(self.G_weighted, backend=backend))
 
     def time_all_pairs_dijkstra_path_length(self, backend, num_nodes, edge_prob):
-        G = get_cached_gnp_random_graph(num_nodes, edge_prob, is_weighted=True)
-        _ = dict(nx.all_pairs_dijkstra_path_length(G, backend=backend))
+        _ = dict(nx.all_pairs_dijkstra_path_length(self.G_weighted, backend=backend))
 
     def time_all_pairs_dijkstra_path(self, backend, num_nodes, edge_prob):
-        G = get_cached_gnp_random_graph(num_nodes, edge_prob, is_weighted=True)
-        _ = dict(nx.all_pairs_dijkstra_path(G, backend=backend))
+        _ = dict(nx.all_pairs_dijkstra_path(self.G_weighted, backend=backend))
 
     def time_all_pairs_bellman_ford_path_length(self, backend, num_nodes, edge_prob):
-        G = get_cached_gnp_random_graph(num_nodes, edge_prob, is_weighted=True)
-        _ = dict(nx.all_pairs_bellman_ford_path_length(G, backend=backend))
+        _ = dict(
+            nx.all_pairs_bellman_ford_path_length(self.G_weighted, backend=backend)
+        )
 
     def time_all_pairs_bellman_ford_path(self, backend, num_nodes, edge_prob):
-        G = get_cached_gnp_random_graph(num_nodes, edge_prob, is_weighted=True)
-        _ = dict(nx.all_pairs_bellman_ford_path(G, backend=backend))
+        _ = dict(nx.all_pairs_bellman_ford_path(self.G_weighted, backend=backend))
 
     def time_johnson(self, backend, num_nodes, edge_prob):
-        G = get_cached_gnp_random_graph(num_nodes, edge_prob, is_weighted=True)
-        _ = nx.johnson(G, backend=backend)
+        _ = nx.johnson(self.G_weighted, backend=backend)

--- a/benchmarks/benchmarks/bench_tournament.py
+++ b/benchmarks/benchmarks/bench_tournament.py
@@ -1,19 +1,27 @@
 from .common import (
     backends,
     num_nodes,
+    seed,
     Benchmark,
 )
 import networkx as nx
+import random
 
 
 class Tournament(Benchmark):
-    params = [(backends), (num_nodes)]
+    params = [backends, num_nodes]
     param_names = ["backend", "num_nodes"]
 
+    def setup(self, backend, num_nodes):
+        self.G = nx.tournament.random_tournament(num_nodes, seed=seed)
+        self.nodes = sorted(self.G)
+        rng = random.Random(seed)
+        self.source, self.target = rng.sample(self.nodes, 2)
+
     def time_is_reachable(self, backend, num_nodes):
-        G = nx.tournament.random_tournament(num_nodes, seed=42)
-        _ = nx.tournament.is_reachable(G, 1, num_nodes, backend=backend)
+        _ = nx.tournament.is_reachable(
+            self.G, self.source, self.target, backend=backend
+        )
 
     def time_tournament_is_strongly_connected(self, backend, num_nodes):
-        G = nx.tournament.random_tournament(num_nodes, seed=42)
-        _ = nx.tournament.is_strongly_connected(G, backend=backend)
+        _ = nx.tournament.is_strongly_connected(self.G, backend=backend)

--- a/benchmarks/benchmarks/bench_vitality.py
+++ b/benchmarks/benchmarks/bench_vitality.py
@@ -12,6 +12,8 @@ class Vitality(Benchmark):
     params = [(backends), (num_nodes), (edge_prob)]
     param_names = ["backend", "num_nodes", "edge_prob"]
 
+    def setup(self, backend, num_nodes, edge_prob):
+        self.G = get_cached_gnp_random_graph(num_nodes, edge_prob)
+
     def time_closeness_vitality(self, backend, num_nodes, edge_prob):
-        G = get_cached_gnp_random_graph(num_nodes, edge_prob)
-        _ = nx.closeness_vitality(G, backend=backend)
+        _ = nx.closeness_vitality(self.G, backend=backend)

--- a/benchmarks/benchmarks/bench_vitality.py
+++ b/benchmarks/benchmarks/bench_vitality.py
@@ -9,7 +9,7 @@ import networkx as nx
 
 
 class Vitality(Benchmark):
-    params = [(backends), (num_nodes), (edge_prob)]
+    params = [backends, num_nodes, edge_prob]
     param_names = ["backend", "num_nodes", "edge_prob"]
 
     def setup(self, backend, num_nodes, edge_prob):

--- a/benchmarks/benchmarks/common.py
+++ b/benchmarks/benchmarks/common.py
@@ -17,13 +17,14 @@ CACHE_ROOT = Path(__file__).resolve().parent.parent / "env" / "nxp_benchdata"
 backends = ["parallel", None]
 num_nodes = [50, 100, 200, 400, 800]
 edge_prob = [0.8, 0.6, 0.4, 0.2]
+seed = 42
 
 
 @lru_cache(typed=True)
 def get_cached_gnp_random_graph(num_nodes, edge_prob, is_weighted=False):
     G = nx.fast_gnp_random_graph(num_nodes, edge_prob, seed=42, directed=False)
     if is_weighted:
-        random.seed(42)
+        random.seed(seed)
         for u, v in G.edges():
             G.edges[u, v]["weight"] = random.random()
     return G

--- a/benchmarks/benchmarks/common.py
+++ b/benchmarks/benchmarks/common.py
@@ -21,8 +21,10 @@ seed = 42
 
 
 @lru_cache(typed=True)
-def get_cached_gnp_random_graph(num_nodes, edge_prob, is_weighted=False):
-    G = nx.fast_gnp_random_graph(num_nodes, edge_prob, seed=42, directed=False)
+def get_cached_gnp_random_graph(
+    num_nodes, edge_prob, is_weighted=False, is_directed=False
+):
+    G = nx.fast_gnp_random_graph(num_nodes, edge_prob, seed=42, directed=is_directed)
     if is_weighted:
         random.seed(seed)
         for u, v in G.edges():


### PR DESCRIPTION
Handles issue #125 

### Summary of changes introduced:
- Introduced a `setup()` function in each benchmark class to handle graph creation and, where necessary, convert the graph to a backend-specific format (e.g., ParallelGraph for `all_pairs_node_connectivity`).
- Used separate attributes (`self.G` for unweighted and `self.G_weighted` for weighted graphs) when a benchmark class required both types.
- Centralized the random seed (`seed = 42`) in common.py for consistent graph generation across all benchmarks.

