### PR TITLE
refactor `test_get_functions_with_get_chunks`

### DIFF
--- a/nx_parallel/interface.py
+++ b/nx_parallel/interface.py
@@ -37,7 +37,7 @@ ALGORITHMS = [
     # Approximation
     "approximate_all_pairs_node_connectivity",
     # Connectivity
-    "connectivity.all_pairs_node_connectivity",
+    "all_pairs_node_connectivity",
 ]
 
 
@@ -69,9 +69,7 @@ class ParallelGraph:
 def assign_algorithms(cls):
     """Class decorator to assign algorithms to the class attributes."""
     for attr in ALGORITHMS:
-        # get the function name by parsing the module hierarchy
-        func_name = attr.rsplit(".", 1)[-1]
-        setattr(cls, func_name, attrgetter(attr)(algorithms))
+        setattr(cls, attr, attrgetter(attr)(algorithms))
     return cls
 
 

--- a/nx_parallel/tests/test_get_chunks.py
+++ b/nx_parallel/tests/test_get_chunks.py
@@ -31,7 +31,7 @@ def get_functions_with_get_chunks(ignore_funcs=[], package_name="nx_parallel"):
 
 
 def test_get_functions_with_get_chunks():
-    assert set(get_functions_with_get_chunks()) == set(ALGORITHMS)
+    assert get_functions_with_get_chunks() == ALGORITHMS
 
 
 ignore_funcs = [

--- a/nx_parallel/tests/test_get_chunks.py
+++ b/nx_parallel/tests/test_get_chunks.py
@@ -31,7 +31,7 @@ def get_functions_with_get_chunks(ignore_funcs=[], package_name="nx_parallel"):
 
 
 def test_get_functions_with_get_chunks():
-    expected = {attr.rsplit(".", 1)[-1] for attr in ALGORITHMS}
+    expected = {algo.rsplit(".", 1)[-1] for algo in ALGORITHMS}
     assert set(get_functions_with_get_chunks()) == expected
 
 

--- a/nx_parallel/tests/test_get_chunks.py
+++ b/nx_parallel/tests/test_get_chunks.py
@@ -31,7 +31,7 @@ def get_functions_with_get_chunks(ignore_funcs=[], package_name="nx_parallel"):
 
 
 def test_get_functions_with_get_chunks():
-    assert get_functions_with_get_chunks() == ALGORITHMS
+    assert list(get_functions_with_get_chunks()) == ALGORITHMS
 
 
 ignore_funcs = [

--- a/nx_parallel/tests/test_get_chunks.py
+++ b/nx_parallel/tests/test_get_chunks.py
@@ -31,7 +31,7 @@ def get_functions_with_get_chunks(ignore_funcs=[], package_name="nx_parallel"):
 
 
 def test_get_functions_with_get_chunks():
-    assert list(get_functions_with_get_chunks()) == ALGORITHMS
+    assert set(get_functions_with_get_chunks()) == set(ALGORITHMS)
 
 
 ignore_funcs = [

--- a/nx_parallel/tests/test_get_chunks.py
+++ b/nx_parallel/tests/test_get_chunks.py
@@ -10,6 +10,7 @@ import networkx as nx
 import pytest
 
 import nx_parallel as nxp
+from nx_parallel.interface import ALGORITHMS
 
 
 def get_functions_with_get_chunks(ignore_funcs=[], package_name="nx_parallel"):
@@ -30,30 +31,7 @@ def get_functions_with_get_chunks(ignore_funcs=[], package_name="nx_parallel"):
 
 
 def test_get_functions_with_get_chunks():
-    # TODO: Instead of `expected` use ALGORTHMS from interface.py
-    # take care of functions like `connectivity.all_pairs_node_connectivity`
-    expected = {
-        "all_pairs_all_shortest_paths",
-        "all_pairs_bellman_ford_path",
-        "all_pairs_bellman_ford_path_length",
-        "all_pairs_dijkstra",
-        "all_pairs_dijkstra_path",
-        "all_pairs_dijkstra_path_length",
-        "all_pairs_node_connectivity",
-        "all_pairs_shortest_path",
-        "all_pairs_shortest_path_length",
-        "approximate_all_pairs_node_connectivity",
-        "betweenness_centrality",
-        "closeness_vitality",
-        "edge_betweenness_centrality",
-        "is_reachable",
-        "johnson",
-        "local_efficiency",
-        "node_redundancy",
-        "number_of_isolates",
-        "square_clustering",
-        "tournament_is_strongly_connected",
-    }
+    expected = {attr.rsplit(".", 1)[-1] for attr in ALGORITHMS}
     assert set(get_functions_with_get_chunks()) == expected
 
 

--- a/nx_parallel/tests/test_get_chunks.py
+++ b/nx_parallel/tests/test_get_chunks.py
@@ -31,8 +31,7 @@ def get_functions_with_get_chunks(ignore_funcs=[], package_name="nx_parallel"):
 
 
 def test_get_functions_with_get_chunks():
-    expected = {algo.rsplit(".", 1)[-1] for algo in ALGORITHMS}
-    assert set(get_functions_with_get_chunks()) == expected
+    assert set(get_functions_with_get_chunks()) == set(ALGORITHMS)
 
 
 ignore_funcs = [


### PR DESCRIPTION
This PR refactors the `test_get_functions_with_get_chunks` test to dynamically use the `ALGORITHMS` from interface.py instead of relying on a hardcoded expected set. It strips module prefixes for algorithms like `connectivity.all_pairs_node_connectivity`.
