### PR TITLE
Update `test_get_chunks` for new algorithms

### DIFF
--- a/nx_parallel/tests/test_get_chunks.py
+++ b/nx_parallel/tests/test_get_chunks.py
@@ -91,7 +91,7 @@ def test_get_chunks(func):
     if isinstance(c1, types.GeneratorType):
         c1_list, c2_list = list(c1), list(c2)
         try:
-            c1, c2 = dict(c1), dict(c2)
+            c1, c2 = dict(c1_list), dict(c2_list)
         except ValueError:
             assert sorted(c1_list) == sorted(c2_list)
         else:


### PR DESCRIPTION
This PR updates `test_get_chunks` to properly handle link prediction algorithms that require node community information.
Without this, these algorithms would fail or raise exceptions when run on graphs lacking the necessary community data. 
It is created in extension to PR #127.

LMKWYT!

[EDIT]: This PR introduces the `test_get_chunks` function that consolidates and extends testing for all newly added algorithms from recent PRs.