### PR TITLE
Timing script for bipartite actually producing bipartite graph

### DIFF
--- a/timing/new_heatmaps/timing_individual_function.py
+++ b/timing/new_heatmaps/timing_individual_function.py
@@ -58,19 +58,21 @@ def time_individual_function(
                     G = nx.bipartite.random_graph(
                         n[ind], m[ind], p, directed=True, seed=seed
                     )
-                    for cur_node in G.nodes:
-                        neighbors = set(G.neighbors(cur_node))
-                        # have atleast 2 outgoing edges
-                        while len(neighbors) < 2:
-                            new_neighbor = seed.choice(
-                                [
-                                    node
-                                    for node in G.nodes
-                                    if node != cur_node and node not in neighbors
-                                ]
-                            )
-                            G.add_edge(cur_node, new_neighbor)
-                            neighbors.add(new_neighbor)
+                    A, B = range(n[ind]), range(n[ind], n[ind] + m[ind])
+                    for source_group, target_group in [(A, B), (B, A)]:
+                        for cur_node in source_group:
+                            neighbors = set(G.neighbors(cur_node))
+                            # have atleast 2 outgoing edges
+                            while len(neighbors) < 2:
+                                new_neighbor = seed.choice(
+                                    [
+                                        node
+                                        for node in target_group
+                                        if node not in neighbors
+                                    ]
+                                )
+                                G.add_edge(cur_node, new_neighbor)
+                                neighbors.add(new_neighbor)
                 else:
                     print(f"Number of Nodes: {num}")
                     G = nx.fast_gnp_random_graph(


### PR DESCRIPTION
As suggested by @akshitasure12 in #156  , the change to timing script is in this PR.

Earlier, the bipartite graph part was not actually producing bipartite graph, this was noticed when the graphs were returning error in latapy_clustering tests.

I have used the fact that nx.bipartite.random_graph partitions the nodes into two parts as follows:

    the first part has node indices 0..n-1
    the second part has node indices n..n+m-1
